### PR TITLE
fix(#18): surface render failures and cap stuck video jobs

### DIFF
--- a/prisma/migrations/20260418020000_video_render_error/migration.sql
+++ b/prisma/migrations/20260418020000_video_render_error/migration.sql
@@ -1,0 +1,3 @@
+-- #18: worker persists fatal failures (crash, RENDER_DEADLINE_MS timeout) so the UI
+-- can switch from "Rendering..." to "Rendering failed" instead of polling forever.
+ALTER TABLE "Video" ADD COLUMN IF NOT EXISTS "renderError" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model Video {
   progress      Int     @default(0)
   /// Non-fatal note the worker persists when a render finished with a caveat (e.g. selected music file missing on the server). Shown in the UI next to "Download started!" (#20).
   renderWarning String? @db.Text
+  /// Set when a render fails (worker exception or RENDER_DEADLINE_MS timeout) so the UI can exit "Rendering…" instead of polling forever (#18).
+  renderError   String? @db.Text
 }
 
 // Necessary for Next auth

--- a/src/components/player/render-button.tsx
+++ b/src/components/player/render-button.tsx
@@ -29,7 +29,7 @@ export function RenderButton({data, setIsOpen}: { data: DiscoData, setIsOpen: (i
   return (
     <>
       <div className="text-center inline-flex flex-wrap justify-center content-center min-h-12 w-full relative">
-        {(status.state === 'not-started' || status.state === 'finished')
+        {(status.state === 'not-started' || status.state === 'finished' || status.state === 'failed')
           ? <>
             <Button onClick={() => send({ convertToGif: true })} variant="ghost">
               <Download className="w-4 h-4 mr-2"/>

--- a/src/components/render-status-provider.tsx
+++ b/src/components/render-status-provider.tsx
@@ -11,7 +11,8 @@ type RenderNotStarted = { state: 'not-started' }
 type RenderInQueue = { state: 'in-queue', videoId: string, isGif: boolean, position: number, maxPosition: number }
 type RenderInProgress = { state: 'in-progress', videoId: string, isGif: boolean, progress: number }
 type RenderFinished = { state: 'finished', videoId: string, isGif: boolean, warning: string | null }
-export type RenderStatus = RenderNotStarted | RenderInQueue | RenderInProgress | RenderFinished
+type RenderFailed = { state: 'failed', videoId: string, isGif: boolean, message: string }
+export type RenderStatus = RenderNotStarted | RenderInQueue | RenderInProgress | RenderFinished | RenderFailed
 
 export const RenderStatusContext = createContext<[RenderStatus, (status: RenderStatus) => void]>(
   [{state: 'not-started'}, () => {}],
@@ -73,6 +74,9 @@ export function RenderStatusProvider({children}: { children: ReactNode }) {
           const result = await getVideoProgress(status.videoId);
           if (result.status === 'progress') {
             setStatus({state: 'in-progress', videoId: status.videoId, isGif: status.isGif, progress: result.progress});
+          } else if (result.status === 'failed') {
+            clearInterval(timer);
+            setStatus({state: 'failed', videoId: status.videoId, isGif: status.isGif, message: result.message});
           } else {
             clearInterval(timer);
             setStatus({state: 'finished', videoId: status.videoId, isGif: status.isGif, warning: result.warning});
@@ -115,13 +119,19 @@ export function RenderStatusProvider({children}: { children: ReactNode }) {
                 }
               </>
             }
+            {status.state === 'failed' &&
+              <>
+                <p className="font-medium text-red-400">Rendering failed</p>
+                <p className="mt-2 max-h-40 overflow-y-auto break-words text-sm text-zinc-400">{status.message}</p>
+              </>
+            }
           </div>
 
           {(status.state === 'in-queue' || status.state === 'in-progress') &&
             <Progress value={displayedProgress} className="mt-3"/>
           }
 
-          {status.state === 'finished' &&
+          {(status.state === 'finished' || status.state === 'failed') &&
             <Button size="icon" variant="ghost" onClick={() => setStatus({state: 'not-started'})}
                     className="absolute right-1 top-1">
               <X className="h-4 w-4"/>

--- a/src/server/server-actions.ts
+++ b/src/server/server-actions.ts
@@ -23,12 +23,19 @@ export async function getVideoQueuePosition(id: string): Promise<number> {
 
 export type VideoProgressResult =
   | { status: 'progress'; progress: number }
-  | { status: 'finished'; warning: string | null };
+  | { status: 'finished'; warning: string | null }
+  | { status: 'failed'; message: string };
 
 export async function getVideoProgress(id: string): Promise<VideoProgressResult> {
   const video = await db.video.findFirst({where: {id}});
-  if (video?.isReady) {
+  if (!video) {
+    return {status: 'failed', message: 'Video not found'};
+  }
+  if (video.isReady) {
     return {status: 'finished', warning: video.renderWarning ?? null};
   }
-  return {status: 'progress', progress: video?.progress ?? 0};
+  if (video.renderError) {
+    return {status: 'failed', message: video.renderError};
+  }
+  return {status: 'progress', progress: video.progress};
 }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -33,6 +33,38 @@ const WEB_URL = env.WEB_URL ?? 'http://localhost:3000'
 const GIF_FPS = 10
 const GIF_WIDTH = 720
 
+/** Wall-clock cap for `video.startAndWait()` so a stuck WebVideoCreator run does not block the worker forever (#18). */
+const DEFAULT_RENDER_DEADLINE_MS = 60 * 60 * 1000;
+
+function renderDeadlineMs(): number {
+  const raw = process.env.RENDER_DEADLINE_MS;
+  if (raw !== undefined && raw !== '') {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) {
+      return n;
+    }
+  }
+  return DEFAULT_RENDER_DEADLINE_MS;
+}
+
+function withDeadline<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return p;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => {
+      reject(new Error(`${label} exceeded ${String(ms)}ms (RENDER_DEADLINE_MS)`));
+    }, ms);
+    p.then(
+      (v) => { clearTimeout(t); resolve(v); },
+      (e: unknown) => {
+        clearTimeout(t);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
 /**
  * HEAD-probe a WEB_URL-relative asset. Returns true only on a 2xx response.
  * Used before wvc.addAudio() so a missing music file (#20) doesn't make the
@@ -48,71 +80,82 @@ async function urlExists(url: string): Promise<boolean> {
 }
 
 async function renderVideo(data: DiscoData, id: string, convertToGif: boolean) {
-  const filename = getVideoPath(id);
-  let renderWarning: string | null = null;
+  try {
+    const filename = getVideoPath(id);
+    let renderWarning: string | null = null;
 
-  const video = wvc.createSingleVideo({
-    url: WEB_URL + '/render',
-    width: 1080,
-    height: 1920,
-    fps: 30,
-    duration: Math.min(totalDuration(data), totalTimeLimit),
-    outputPath: filename,
-    pagePrepareFn: async (page: Page) => {
-      const puppeteerPage = page.target as PuppeteerPage;
-      const serialized = serialize(data);
-      await puppeteerPage.evaluate(({serialized}) => {
-        localStorage.setItem('data', serialized);
-        window.dispatchEvent(new Event('disco', {}));
-      }, { serialized });
-    },
-  });
+    const video = wvc.createSingleVideo({
+      url: WEB_URL + '/render',
+      width: 1080,
+      height: 1920,
+      fps: 30,
+      duration: Math.min(totalDuration(data), totalTimeLimit),
+      outputPath: filename,
+      pagePrepareFn: async (page: Page) => {
+        const puppeteerPage = page.target as PuppeteerPage;
+        const serialized = serialize(data);
+        await puppeteerPage.evaluate(({serialized}) => {
+          localStorage.setItem('data', serialized);
+          window.dispatchEvent(new Event('disco', {}));
+        }, { serialized });
+      },
+    });
 
-  // GIFs have no audio track (ffmpeg paletteuse drops audio), so there is no
-  // reason to fetch the music file at all. Skipping unconditionally makes the
-  // gif path bulletproof against #20 even if the user picked a missing track.
-  if (data.music && !convertToGif) {
-    const musicUrl = WEB_URL + data.music;
-    if (await urlExists(musicUrl)) {
-      video.addAudio({
-        url: musicUrl,
-        volume: 20,
-        loop: true,
-        seekStart: data.skipMusicIntro ? 37000 : 0,
-      });
-    } else {
-      // Skip addAudio so wvc's Synthesizer doesn't 404 mid-render (#20).
-      // The render still succeeds - just silent - and the UI surfaces this.
-      renderWarning = `Rendered without music: "${data.music}" was not found on the server.`;
-      console.warn(`[worker] ${renderWarning}`);
+    // GIFs have no audio track (ffmpeg paletteuse drops audio), so there is no
+    // reason to fetch the music file at all. Skipping unconditionally makes the
+    // gif path bulletproof against #20 even if the user picked a missing track.
+    if (data.music && !convertToGif) {
+      const musicUrl = WEB_URL + data.music;
+      if (await urlExists(musicUrl)) {
+        video.addAudio({
+          url: musicUrl,
+          volume: 20,
+          loop: true,
+          seekStart: data.skipMusicIntro ? 37000 : 0,
+        });
+      } else {
+        // Skip addAudio so wvc's Synthesizer doesn't 404 mid-render (#20).
+        // The render still succeeds - just silent - and the UI surfaces this.
+        renderWarning = `Rendered without music: "${data.music}" was not found on the server.`;
+        console.warn(`[worker] ${renderWarning}`);
+      }
     }
-  }
 
-  video.on("progress", async (progress: number) => {
-    await db.video.update({where: {id}, data: {progress: Math.floor(progress)}}).catch(console.error);
-  });
-  await video.startAndWait();
-
-  if (convertToGif) {
-    await run(
-      `ffmpeg`,
-      `-i`, filename,
-      `-vf`, `fps=${GIF_FPS},scale=${GIF_WIDTH}:-1:flags=lanczos,palettegen`,
-      `${filename}.palette.png`,
-      `-update`, `true`,
-      `-nostdin`,
+    video.on("progress", async (progress: number) => {
+      await db.video.update({where: {id}, data: {progress: Math.floor(progress)}}).catch(console.error);
+    });
+    await withDeadline(
+      video.startAndWait() as Promise<void>,
+      renderDeadlineMs(),
+      'video.startAndWait',
     );
-    await run(
-      `ffmpeg`,
-      `-i`, filename,
-      `-i`, `${filename}.palette.png`,
-      `-lavfi`, `fps=${GIF_FPS},scale=${GIF_WIDTH}:-1:flags=lanczos [x]; [x][1:v] paletteuse`,
-      `-nostdin`,
-      getGifPath(id),
-    );
-  }
 
-  await db.video.update({where: {id}, data: {isReady: true, renderWarning}});
+    if (convertToGif) {
+      await run(
+        `ffmpeg`,
+        `-i`, filename,
+        `-vf`, `fps=${GIF_FPS},scale=${GIF_WIDTH}:-1:flags=lanczos,palettegen`,
+        `${filename}.palette.png`,
+        `-update`, `true`,
+        `-nostdin`,
+      );
+      await run(
+        `ffmpeg`,
+        `-i`, filename,
+        `-i`, `${filename}.palette.png`,
+        `-lavfi`, `fps=${GIF_FPS},scale=${GIF_WIDTH}:-1:flags=lanczos [x]; [x][1:v] paletteuse`,
+        `-nostdin`,
+        getGifPath(id),
+      );
+    }
+
+    await db.video.update({where: {id}, data: {isReady: true, renderWarning, renderError: null}});
+  } catch (err) {
+    // #18: surface fatal render failures to the UI instead of letting the client poll forever.
+    const message = String(err).slice(0, 8000);
+    await db.video.update({where: {id}, data: {renderError: message}}).catch(console.error);
+    throw err;
+  }
 }
 
 function run(command: string, ...args: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

**Stacks on #21.** Review after the music PR lands; until then the diff on this PR will include #21's commits too.

Addresses the long-tail of #18: users still occasionally hit "Rendering…" that never advances for *reasons other than* the missing-music bug fixed in #21. Any failure inside the worker — Puppeteer/Chrome crash, ffmpeg exit code (from an error), `web-video-creator` Synthesizer throwing — leaves `pgboss.job.state='active'` and `Video.isReady=false` forever, so the client keeps polling `getVideoProgress` indefinitely.

Two complementary levers, both host-agnostic:

- **`RENDER_DEADLINE_MS`**: wraps `wvc.startAndWait()` in a race-with-`setTimeout` helper. Default 60 minutes, override via env. When it fires the worker throws, which feeds the next lever.
- **`Video.renderError` + try/catch**: the whole `renderVideo` body is wrapped; on any exception the message is persisted to a new `Video.renderError` text column, then rethrown so pg-boss retry/backoff still behaves correctly. On success `renderError` is cleared.

Client side:

- `getVideoProgress` now returns a tagged union `{status:'progress',progress} | {status:'finished',warning} | {status:'failed',message}`.
- `RenderStatusProvider` adds a `failed` state that renders a red "Rendering failed" banner with the message and a close button.
- `RenderButton` re-enables the Render GIF / Render video buttons after a failed render so the user can retry without reloading the page.

## Not in-scope

- Not investigating or fixing a specific root cause of a non-music #18 failure. The intent here is to make any future failure **visible and bounded** rather than an indefinite spinner.
- No Vercel-specific code (no `@vercel/blob`, no Deployment Protection bypass, no `binaryTargets`).

## Verification

Rebuilt the Docker stack from this branch. Injected `RENDER_DEADLINE_MS=5000` into the worker service via compose override to force a timeout, then clicked Render in the UI:

```
 Video.id | isReady | progress | renderError
----------+---------+----------+-------------------------------------------------------------------
 75919288 |   f     |   100    | Error: video.startAndWait exceeded 5000ms (RENDER_DEADLINE_MS)
```

UI showed the red "Rendering failed" banner with the full error message and a close button (screenshot to attach). After clicking close, Render buttons were re-enabled and a second attempt worked (with the override removed).

Regression test against #21: with `RENDER_DEADLINE_MS` unset, a normal render on `music: null` still completes cleanly and no `renderError` is written.

## Screenshots
<img width="1804" height="2468" alt="image" src="https://github.com/user-attachments/assets/2559d6c8-3458-463d-ba20-b2631cd8ceab" />

## Test plan

- [ ] `docker compose up -d --build`, click Render → renders complete, `renderError` stays null.
- [ ] Temporarily set `RENDER_DEADLINE_MS=5000` on the worker, click Render → UI shows "Rendering failed" with the deadline message, close button clears the toast, Render buttons are usable again.
- [ ] Kill the worker container mid-render (`docker compose kill worker`) → after pg-boss retry window, `renderError` is set and the UI switches to failed.

Made with [Cursor](https://cursor.com)